### PR TITLE
ci: add aggregate All checks passed gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,3 +70,21 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Validate yarn.lock registry URLs and integrity
         run: yarn lint:lockfile
+
+  all-checks-passed:
+    # Single aggregate gate for branch protection. Keep this job's `needs`
+    # list in sync with every mandatory job above — branch protection requires
+    # only this context, so adding/removing a mandatory job is a workflow
+    # edit, not a branch-protection edit.
+    name: All checks passed
+    needs: [build, audit, lockfile-lint]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all dependencies succeeded
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]] || \
+             [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "::error::One or more required jobs did not succeed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Adds an `all-checks-passed` job to `.github/workflows/main.yml` with `needs: [build, audit, lockfile-lint]`, `if: always()`, failing on any dependency failure or cancellation.
- Unblocks branch protection on `main` to require a single status check (`All checks passed`) — so adding or removing a mandatory job becomes a workflow edit (update `needs:`) rather than a branch-protection edit.

## Why

Branch protection currently has no required status checks. Listing each job individually makes future job additions a two-step dance (workflow + branch protection). The aggregate meta-job pattern is the org default.

## Follow-up after merge

Once the first run of this workflow on `main` posts the `All checks passed` context, the required status check can be enabled with `strict: true` (required conversation resolution, 2 reviews, dismiss-stale, etc. are already configured).

## Test plan

- [ ] Workflow runs on this PR; `All checks passed` job appears and succeeds
- [ ] Verify that a failing upstream job would fail the aggregate (via `contains(needs.*.result, 'failure')` guard)
