### PR TITLE
fix(deps): bump qs to 6.15.2 

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "next-sitemap": "4.2.3",
     "path": "0.12.7",
     "pdfjs-dist": "4.9.155",
-    "qs": "6.14.2",
+    "qs": "6.15.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-markdown": "9.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3433,10 +3433,10 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@6.14.2:
-  version "6.14.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
-  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
+qs@6.15.2:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
## Summary

Bump `qs` `6.14.2 → 6.15.2` to clear **GHSA-q8mj-m7cp-5q26** (medium DoS, disclosed 2026-05-23 — surfaced as 2 new Dependabot alerts after PR #61 merged):

> qs.stringify crashes with `TypeError` on null/undefined entries in comma-format arrays when `encodeValuesOnly` is set. Vulnerable: `>= 6.11.1, <= 6.15.1`. Fix: `>= 6.15.2`.

`qs` is a direct production dep used by the CMS proxy ([`pages/api/posts/index.ts`](pages/api/posts/index.ts), [`pages/api/posts/[id].ts`](pages/api/posts/[id].ts)).

## Version choice
`6.15.2` is the latest, published 2026-05-16 (9 days ago — satisfies the 7-day cooldown; also covered by SUPPLY-CHAIN-SECURITY.md §4 disclosed-advisory exemption). Single hoisted resolution in the lockfile; no transitive copies, no `resolutions` entry needed.

## Verification (local, Node 22)

- `yarn audit --groups dependencies` → **0 vulnerabilities**
- `yarn build` ✅ · `yarn lint` ✅ · `yarn lint:lockfile` ✅
- `yarn audit:prod` ✅ · `yarn audit:install-hooks` ✅

## Net Dependabot impact

Open alerts before: 2 (both this advisory). After merge: **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)