### PR TITLE
chore(supply-chain): add non-blocking license allowlist gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,29 @@ jobs:
       - name: Diff install-hook surface against allowlist
         run: yarn audit:install-hooks
 
+  license-check:
+    name: License allowlist gate
+    # License allowlist gate (PARANOID):
+    # every production dependency's license must be on the allowlist in
+    # .supply-chain/license-allowlist.json, or be a reasoned exemption.
+    # NON-BLOCKING PILOT: deliberately NOT in `all-checks-passed.needs` below, so
+    # it reports without gating merges. Promote to required by adding it to that
+    # `needs:` array (+ branch protection). See .plans/license-check-gate.md.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: '.nvmrc'
+      - name: Activate pinned Yarn via Corepack
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+      - name: Install modules
+        run: yarn install --frozen-lockfile
+      - name: Check production dependency licenses
+        run: yarn license-check
+
   all-checks-passed:
     # Single aggregate gate for branch protection. Keep this job's `needs`
     # list in sync with every mandatory job above — branch protection requires

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
     # .supply-chain/license-allowlist.json, or be a reasoned exemption.
     # NON-BLOCKING PILOT: deliberately NOT in `all-checks-passed.needs` below, so
     # it reports without gating merges. Promote to required by adding it to that
-    # `needs:` array (+ branch protection). See .plans/license-check-gate.md.
+    # `needs:` array (+ branch protection). See SUPPLY-CHAIN-SECURITY.md §9.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -109,6 +109,10 @@ jobs:
           corepack prepare yarn@1.22.22 --activate
       - name: Install modules
         run: yarn install --frozen-lockfile
+      - name: Run evaluator unit tests
+        # Guards the hand-rolled SPDX OR/AND precedence + alias normalization in
+        # license-check.lib.mjs against silent regressions. Pure node:test, no deps.
+        run: yarn license-check:test
       - name: Check production dependency licenses
         run: yarn license-check
 

--- a/.supply-chain/license-allowlist.json
+++ b/.supply-chain/license-allowlist.json
@@ -1,0 +1,49 @@
+{
+  "_comment": "License allowlist gate config (PARANOID). A PRODUCTION dependency whose license is not in `allowedSpdx` — including UNKNOWN/Custom — FAILS, unless (1) a `licenseOverrides` correction, (2) its exact NAME is in `exemptions`, or (3) its name matches an `exemptionPrefixes` entry. Read by scripts/license-check.mjs. Plain JSON — no comments; document with _-prefixed string keys.",
+
+  "scope": "production",
+
+  "allowedSpdx": [
+    "MIT",
+    "MIT-0",
+    "ISC",
+    "Apache-2.0",
+    "BSD",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "0BSD",
+    "MPL-2.0",
+    "LGPL-2.1",
+    "LGPL-2.1-only",
+    "LGPL-2.1-or-later",
+    "LGPL-2.1+",
+    "Python-2.0",
+    "BlueOak-1.0.0",
+    "CC0-1.0",
+    "Unlicense",
+    "Public Domain",
+    "WTFPL",
+    "Zlib",
+    "OFL-1.1",
+    "CC-BY-4.0",
+    "CC-BY-3.0",
+    "Artistic-2.0"
+  ],
+
+  "unauthorizedSpdx": ["GPL-2.0", "GPL-3.0", "GPL-3.0+", "LGPL-3.0", "MPL-1.1", "AGPL-3.0"],
+
+  "licenseOverrides": [],
+
+  "exemptions": [],
+
+  "exemptionPrefixes": [
+    {
+      "prefix": "@img/sharp-libvips-",
+      "spdx": "LGPL-3.0-or-later",
+      "reason": "Next.js image-optimizer native lib (libvips), pulled via next > sharp. Dynamically-loaded native binary, not statically combined with our JS. Package name varies by OS/arch (@img/sharp-libvips-darwin-arm64 locally, @img/sharp-libvips-linux-x64 on CI), so a narrow publisher-controlled prefix is used rather than a non-deterministic exact name.",
+      "parents": ["sharp"],
+      "added": "2026-06-05",
+      "review": "2027-06-05"
+    }
+  ]
+}

--- a/SUPPLY-CHAIN-SECURITY.md
+++ b/SUPPLY-CHAIN-SECURITY.md
@@ -113,6 +113,16 @@ The runtime and build environments for `valory-website` hold a deliberately smal
 
 The workflow installs the **OSS gitleaks CLI as a checksum-verified binary** rather than using `gitleaks/gitleaks-action`, because that action requires a paid license for organisation-owned repos. Bump the `VERSION` and `SHA256` env vars together (the checksum is version-specific). If a legitimate high-entropy string ever trips a false positive (e.g. an example token in a fixture), add a `.gitleaks.toml` allowlist at the repo root to suppress it by regex.
 
+### 9. License allowlist gate
+
+The `license-check` job in [.github/workflows/main.yml](./.github/workflows/main.yml) runs `yarn license-check`, a gate at [`scripts/license-check.mjs`](./scripts/license-check.mjs) (SPDX evaluator in [`scripts/license-check.lib.mjs`](./scripts/license-check.lib.mjs)). It enforces a **PARANOID** policy over the production dependency tree: every production dependency's license must be on the allowlist in [`.supply-chain/license-allowlist.json`](./.supply-chain/license-allowlist.json), be corrected by a `licenseOverrides` entry, or be an explicitly-reasoned exemption. `UNKNOWN` or unlisted licenses **fail** — they are resolved, not silenced. Like the `audit` gate ([§5](#5-audit-in-ci)), `scope` is `production`: `devDependencies` do not ship and generate substantial transitive-license noise, so they are excluded by policy.
+
+The engine is [`license-checker-rseidelsohn`](https://www.npmjs.com/package/license-checker-rseidelsohn) (pinned to the 4.x line in [`package.json`](./package.json); 5.x requires Node 24). The original `license-checker` reports any package with no SPDX string in its `package.json` as `UNKNOWN`; the rseidelsohn fork reads the actual `LICENSE` file in those cases, giving a real classification surface instead of false `UNKNOWN`s. The SPDX `OR`/`AND` precedence logic is hand-rolled and **unit-tested** in [`scripts/license-check.test.mjs`](./scripts/license-check.test.mjs) (pure `node:test`, run in the same CI job via `yarn license-check:test`), so precedence/alias regressions cannot ship silently.
+
+Exemptions come in two shapes, both requiring the same `reason` + `review`-date discipline as [`audit-allowlist.json`](./.supply-chain/audit-allowlist.json): by **exact package name** (version-agnostic) for individual packages, and by a **narrow publisher-controlled prefix** only for platform-binary families. The one current exemption is the `@img/sharp-libvips-` prefix (LGPL-3.0 dynamically-loaded `libvips` native binary, pulled via `next > sharp`).
+
+**Non-blocking pilot.** This job is deliberately **not** in `all-checks-passed.needs`, so it reports on every PR but cannot fail a merge yet. Promote it to required by adding `license-check` to that `needs:` array and the corresponding branch-protection check — do this once the `@img/sharp-libvips-` exemption is signed off.
+
 ## Response playbook: "a dependency we use was just disclosed as compromised"
 
 1. **Identify exposure.** `yarn why <pkg>` — direct or transitive? Which version is in our lockfile?
@@ -135,6 +145,8 @@ The workflow installs the **OSS gitleaks CLI as a checksum-verified binary** rat
 - [x] Add the install-hook diff gate ([`scripts/audit-install-hooks.mjs`](./scripts/audit-install-hooks.mjs) + [`.supply-chain/install-hooks.allowlist`](./.supply-chain/install-hooks.allowlist)), wired into `all-checks-passed`.
 - [x] Add [`.nvmrc`](./.nvmrc) (Node `20.20.2`, consumed by CI via `node-version-file`) and [`.yarnrc`](./.yarnrc) (`--save-exact true`; no global `ignore-scripts`).
 - [x] Add the gitleaks secret-scanning workflow ([.github/workflows/secret-scan.yml](./.github/workflows/secret-scan.yml)).
+- [x] Add the license allowlist gate ([`scripts/license-check.mjs`](./scripts/license-check.mjs) + [`.supply-chain/license-allowlist.json`](./.supply-chain/license-allowlist.json)) as a non-blocking pilot — see [§9](#9-license-allowlist-gate).
+- [ ] Promote `license-check` to required (add to `all-checks-passed.needs` + branch protection) once the `@img/sharp-libvips-` exemption is signed off.
 - [x] Add [`.github/CODEOWNERS`](./.github/CODEOWNERS) routing supply-chain paths to the security owners (`@Tanya-atatakai`, `@atepem`).
 - [ ] Enable "Require review from Code Owners" in `main` branch protection so CODEOWNERS enforces (it only suggests reviewers otherwise).
 - [ ] Add the gitleaks check and `all-checks-passed` as required status checks in `main` branch protection.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@types/node": "20.17.10",
-    "license-checker-rseidelsohn": "4.4.2",
     "@types/qs": "6.9.17",
     "@types/react": "18.3.18",
     "@types/react-dom": "18.3.5",
@@ -44,6 +43,7 @@
     "eslint-config-next": "15.5.18",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.2.1",
+    "license-checker-rseidelsohn": "4.4.2",
     "lockfile-lint": "5.0.0",
     "postcss": "8.5.14",
     "prettier": "3.4.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint:lockfile": "lockfile-lint --path yarn.lock --type yarn --allowed-hosts yarn npm --allowed-schemes https: --validate-integrity",
     "audit:prod": "node scripts/audit.mjs",
     "audit:install-hooks": "node scripts/audit-install-hooks.mjs",
-    "audit:install-hooks:update": "node scripts/audit-install-hooks.mjs --update"
+    "audit:install-hooks:update": "node scripts/audit-install-hooks.mjs --update",
+    "license-check": "node scripts/license-check.mjs",
+    "license-check:test": "node --test scripts/license-check.test.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "5.1.0",
@@ -33,6 +35,7 @@
   },
   "devDependencies": {
     "@types/node": "20.17.10",
+    "license-checker-rseidelsohn": "4.4.2",
     "@types/qs": "6.9.17",
     "@types/react": "18.3.18",
     "@types/react-dom": "18.3.5",

--- a/scripts/license-check.lib.mjs
+++ b/scripts/license-check.lib.mjs
@@ -1,0 +1,87 @@
+/**
+ * Pure helpers extracted from license-check.mjs so they can be unit-tested
+ * without firing the script's top-level side effects (allowlist load,
+ * checker.init scan, process.exit). Imported by both the script and
+ * license-check.test.mjs.
+ *
+ * No I/O, no exit, no global state — same input → same output.
+ */
+
+// Aliases for npm-ecosystem license strings that mean an SPDX identifier
+// but don't match it character-for-character. Lower-cased on both sides.
+export const NORMALIZE = new Map([
+  ['apache2', 'Apache-2.0'],
+  ['apache 2.0', 'Apache-2.0'],
+  ['apache license 2.0', 'Apache-2.0'],
+  ['apache license, version 2.0', 'Apache-2.0'],
+  ['apache license version 2.0', 'Apache-2.0'],
+  ['apache software license', 'Apache-2.0'],
+  ['expat', 'MIT'],
+  ['mit license', 'MIT'],
+  ['new bsd', 'BSD-3-Clause'],
+  ['(new) bsd', 'BSD-3-Clause'],
+  ['simplified bsd', 'BSD-2-Clause'],
+  ['3-clause bsd', 'BSD-3-Clause'],
+  ['bsd 3-clause', 'BSD-3-Clause'],
+]);
+
+/**
+ * Strip surrounding parens AND the trailing `*` that license-checker-rseidelsohn
+ * appends when the SPDX was inferred from the LICENSE file rather than declared
+ * in package.json. Apply alias map case-insensitively. Lookup must succeed on
+ * `MIT*` and `Apache2` the same as on `MIT` / `Apache-2.0`.
+ */
+export function normalize(token) {
+  const t = String(token)
+    .replace(/^[()]+|[()]+$/g, '')
+    .replace(/\*+$/, '')
+    .trim();
+  return NORMALIZE.get(t.toLowerCase()) || t;
+}
+
+/**
+ * Evaluate an SPDX-ish license expression against the allow/deny lists.
+ * Returns 'allowed' | 'unauthorized' | 'unknown'.
+ *
+ * SPDX precedence: AND binds tighter than OR. `A AND B OR C` === `(A AND B) OR C`.
+ * Splitting on OR at the top level naturally respects this (recursion handles AND
+ * inside each disjunct).
+ *
+ * - Array of strings → npm legacy OR (any allowed → allowed; all unauthorized → unauthorized).
+ * - String with " OR " → SPDX OR.
+ * - String with " AND " → SPDX AND.
+ * - Plain string → look up directly (after normalization, incl. `*` strip).
+ */
+export function evalExpr(raw, allowedSet, unauthorizedSet) {
+  if (raw == null) return 'unknown';
+
+  if (Array.isArray(raw)) {
+    const parts = raw.map(normalize);
+    if (parts.some((p) => allowedSet.has(p))) return 'allowed';
+    if (parts.length && parts.every((p) => unauthorizedSet.has(p))) return 'unauthorized';
+    return 'unknown';
+  }
+
+  const s = String(raw).trim();
+  if (!s || /^UNKNOWN$/i.test(s) || /^UNLICENSED$/i.test(s) || /^Custom:/i.test(s)) return 'unknown';
+
+  const inner = s.replace(/^\((.*)\)$/, '$1');
+
+  if (/\sOR\s/i.test(inner)) {
+    const parts = inner.split(/\sOR\s/i).map((p) => evalExpr(p, allowedSet, unauthorizedSet));
+    if (parts.some((p) => p === 'allowed')) return 'allowed';
+    if (parts.every((p) => p === 'unauthorized')) return 'unauthorized';
+    return 'unknown';
+  }
+  if (/\sAND\s/i.test(inner)) {
+    const parts = inner.split(/\sAND\s/i).map((p) => evalExpr(p, allowedSet, unauthorizedSet));
+    if (parts.some((p) => p === 'unauthorized')) return 'unauthorized';
+    if (parts.every((p) => p === 'allowed')) return 'allowed';
+    return 'unknown';
+  }
+
+  const t = normalize(inner);
+  if (allowedSet.has(t)) return 'allowed';
+  if (unauthorizedSet.has(t)) return 'unauthorized';
+  return 'unknown';
+}

--- a/scripts/license-check.lib.mjs
+++ b/scripts/license-check.lib.mjs
@@ -7,6 +7,8 @@
  * No I/O, no exit, no global state — same input → same output.
  */
 
+/* eslint-disable no-undef -- standalone module: uses JS built-in globals (works across legacy + flat eslint configs) */
+
 // Aliases for npm-ecosystem license strings that mean an SPDX identifier
 // but don't match it character-for-character. Lower-cased on both sides.
 export const NORMALIZE = new Map([

--- a/scripts/license-check.mjs
+++ b/scripts/license-check.mjs
@@ -23,14 +23,18 @@
  * its own .supply-chain/license-allowlist.json). See README.md.
  */
 
+/* eslint-disable no-undef, no-console -- standalone Node CLI: uses Node/JS globals and reports on stdout/stderr (works across legacy + flat eslint configs) */
+
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve, relative } from 'node:path';
-import { createRequire } from 'node:module';
 
-import { normalize, evalExpr } from './license-check.lib.mjs';
+// Static ESM import: license-checker-rseidelsohn is `type: module`, so a
+// `require()` of it throws ERR_REQUIRE_ESM on Node < 22 (Node 22 added
+// require(esm)). `import * as` works on every supported Node. `init` is a
+// named export.
+import * as checker from 'license-checker-rseidelsohn';
 
-const require = createRequire(import.meta.url);
-const checker = require('license-checker-rseidelsohn');
+import { evalExpr } from './license-check.lib.mjs';
 
 const ROOT = resolve('.');
 const ALLOWLIST_PATH = resolve(ROOT, '.supply-chain/license-allowlist.json');
@@ -38,14 +42,19 @@ const ALLOWLIST_PATH = resolve(ROOT, '.supply-chain/license-allowlist.json');
 // Bound the checker so a stuck node_modules walk (broken symlink loop,
 // filesystem hiccup) can't pin the CI job to the workflow-level timeout.
 const CHECKER_TIMEOUT_MS = 5 * 60 * 1000;
-const SELF_PKG = (() => {
+const ROOT_PKG = (() => {
   try {
-    const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8'));
-    return `${pkg.name}@${pkg.version}`;
+    return JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8'));
   } catch {
-    return null;
+    return {};
   }
 })();
+const SELF_PKG = ROOT_PKG.name && ROOT_PKG.version ? `${ROOT_PKG.name}@${ROOT_PKG.version}` : null;
+// Direct production dependencies — used as a sanity floor: the production scan
+// MUST contain most of these. `license-checker`'s read-installed can silently
+// return a near-empty tree on some installs (transitive read-installed-packages
+// conflicts), which would otherwise make the gate pass vacuously (false green).
+const DIRECT_PROD_DEPS = Object.keys(ROOT_PKG.dependencies || {});
 
 function loadAllowlist() {
   if (!existsSync(ALLOWLIST_PATH)) {
@@ -115,6 +124,28 @@ checker.init(initOpts, (err, report) => {
   if (err) {
     console.error('::error::license-checker failed to scan the dependency tree:', err.message || err);
     process.exit(2);
+  }
+
+  // Scan-completeness guard (fail loud, never false-green): if the scan didn't
+  // even surface most of the repo's own direct production dependencies, the
+  // dependency-tree read is broken — do NOT report a pass.
+  const scannedNames = new Set(
+    Object.keys(report)
+      .filter((k) => k !== SELF_PKG)
+      .map((k) => (k.lastIndexOf('@') > 0 ? k.slice(0, k.lastIndexOf('@')) : k)),
+  );
+  if (DIRECT_PROD_DEPS.length > 0) {
+    const present = DIRECT_PROD_DEPS.filter((d) => scannedNames.has(d)).length;
+    if (present < Math.ceil(DIRECT_PROD_DEPS.length / 2)) {
+      console.error(
+        `::error::license-check: scan looks incomplete — only ${present}/${DIRECT_PROD_DEPS.length} ` +
+          `direct production dependencies were found in a scan of ${scannedNames.size} package(s). ` +
+          `The dependency tree could not be read reliably (often a transitive ` +
+          `read-installed-packages conflict). Refusing to report a pass. ` +
+          `Try a clean reinstall (rm -rf node_modules && yarn install).`,
+      );
+      process.exit(2);
+    }
   }
 
   const violations = [];
@@ -262,6 +293,8 @@ checker.init(initOpts, (err, report) => {
   }
 
   const acceptedSummary = `${overridden.length} overridden, ${exempted.length} exempted by name, ${prefixHits.size} prefix group(s)`;
-  console.log(`license-check: OK (${acceptedSummary}, 0 violations) — scope=${scope}.`);
+  console.log(
+    `license-check: OK (${scannedNames.size} pkgs scanned, ${acceptedSummary}, 0 violations) — scope=${scope}.`,
+  );
   process.exit(0);
 });

--- a/scripts/license-check.mjs
+++ b/scripts/license-check.mjs
@@ -20,7 +20,7 @@
  * .supply-chain/license-allowlist.json (resolved against process.cwd()),
  * and add `license-checker-rseidelsohn` as a devDependency. For a multi-tree
  * repo, run it once per tree from each tree's working directory (each reads
- * its own .supply-chain/license-allowlist.json). See README.md.
+ * its own .supply-chain/license-allowlist.json). See SUPPLY-CHAIN-SECURITY.md §9.
  */
 
 /* eslint-disable no-undef, no-console -- standalone Node CLI: uses Node/JS globals and reports on stdout/stderr (works across legacy + flat eslint configs) */

--- a/scripts/license-check.mjs
+++ b/scripts/license-check.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * License allowlist gate (PARANOID posture). Every PRODUCTION
+ * dependency's license must be in the allowlist, resolved by a
+ * `licenseOverrides` entry, or exempted (by exact NAME for general
+ * packages, by NARROW PREFIX only for publisher-controlled platform-binary
+ * families). UNKNOWN / unlisted licenses FAIL — they are resolved, not
+ * silenced.
+ *
+ * Scope = production. devDependencies don't ship and generate considerable
+ * transitive-license noise, so they are not scanned. Override via
+ * `"scope": "all"` in the config if a future need arises.
+ *
+ * Necessary because npm has no native enforcement gate for license policy.
+ * `license-checker` (the original) reports any package without an SPDX
+ * string in its package.json as UNKNOWN. The rseidelsohn fork reads
+ * LICENSE files for those, giving a real classification surface.
+ *
+ * Drop-in: place beside license-check.lib.mjs, add a config at
+ * .supply-chain/license-allowlist.json (resolved against process.cwd()),
+ * and add `license-checker-rseidelsohn` as a devDependency. For a multi-tree
+ * repo, run it once per tree from each tree's working directory (each reads
+ * its own .supply-chain/license-allowlist.json). See README.md.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, relative } from 'node:path';
+import { createRequire } from 'node:module';
+
+import { normalize, evalExpr } from './license-check.lib.mjs';
+
+const require = createRequire(import.meta.url);
+const checker = require('license-checker-rseidelsohn');
+
+const ROOT = resolve('.');
+const ALLOWLIST_PATH = resolve(ROOT, '.supply-chain/license-allowlist.json');
+
+// Bound the checker so a stuck node_modules walk (broken symlink loop,
+// filesystem hiccup) can't pin the CI job to the workflow-level timeout.
+const CHECKER_TIMEOUT_MS = 5 * 60 * 1000;
+const SELF_PKG = (() => {
+  try {
+    const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8'));
+    return `${pkg.name}@${pkg.version}`;
+  } catch {
+    return null;
+  }
+})();
+
+function loadAllowlist() {
+  if (!existsSync(ALLOWLIST_PATH)) {
+    console.error(`::error::missing ${ALLOWLIST_PATH}`);
+    process.exit(2);
+  }
+  let data;
+  try {
+    data = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8'));
+  } catch (err) {
+    console.error(`::error::failed to parse ${ALLOWLIST_PATH}: ${err.message}`);
+    process.exit(2);
+  }
+  const validateEntry = (entry, kind, keyField) => {
+    const errors = [];
+    if (typeof entry[keyField] !== 'string' || !entry[keyField].trim()) errors.push(`\`${keyField}\` is required`);
+    if (typeof entry.spdx !== 'string' || !entry.spdx.trim()) errors.push('`spdx` is required');
+    if (typeof entry.reason !== 'string' || !entry.reason.trim()) errors.push('`reason` is required');
+    if (typeof entry.added !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(entry.added)) {
+      errors.push('`added` must be YYYY-MM-DD');
+    }
+    if (typeof entry.review !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(entry.review)) {
+      errors.push('`review` must be YYYY-MM-DD');
+    }
+    if (errors.length) {
+      console.error(`::error::malformed ${kind} entry in ${ALLOWLIST_PATH}: ${errors.join('; ')} — ${JSON.stringify(entry)}`);
+      process.exit(2);
+    }
+  };
+  for (const entry of data.licenseOverrides || []) validateEntry(entry, 'licenseOverrides', 'package');
+  for (const entry of data.exemptions || []) validateEntry(entry, 'exemptions', 'package');
+  for (const entry of data.exemptionPrefixes || []) validateEntry(entry, 'exemptionPrefixes', 'prefix');
+  return data;
+}
+
+const allowlist = loadAllowlist();
+const allowedSet = new Set(allowlist.allowedSpdx || []);
+const unauthorizedSet = new Set(allowlist.unauthorizedSpdx || []);
+const overrideByName = new Map();
+for (const e of allowlist.licenseOverrides || []) overrideByName.set(e.package, e);
+const exemptByName = new Map();
+for (const e of allowlist.exemptions || []) exemptByName.set(e.package, e);
+// Most-specific-wins: sort by prefix length desc so a future `@img/sharp-` entry
+// resolves before `@img/`. Without this, ordering is implicit and easy to get wrong.
+const exemptPrefixes = [...(allowlist.exemptionPrefixes || [])].sort(
+  (a, b) => b.prefix.length - a.prefix.length,
+);
+
+const scope = allowlist.scope || 'production';
+if (scope !== 'production' && scope !== 'all') {
+  console.error(`::error::invalid scope "${scope}" in ${ALLOWLIST_PATH} (must be "production" or "all")`);
+  process.exit(2);
+}
+
+const initOpts = { start: ROOT, excludePrivatePackages: true };
+if (scope === 'production') initOpts.production = true;
+
+const timeoutHandle = setTimeout(() => {
+  console.error(
+    `::error::license-checker did not finish within ${CHECKER_TIMEOUT_MS / 1000}s — aborting.`,
+  );
+  process.exit(2);
+}, CHECKER_TIMEOUT_MS);
+
+checker.init(initOpts, (err, report) => {
+  clearTimeout(timeoutHandle);
+  if (err) {
+    console.error('::error::license-checker failed to scan the dependency tree:', err.message || err);
+    process.exit(2);
+  }
+
+  const violations = [];
+  const overridden = [];
+  const exempted = [];
+  const prefixHits = new Map();
+
+  const today = new Date().toISOString().slice(0, 10);
+  const expired = [];
+  const matchedNames = new Set();
+  const matchedPrefixes = new Set();
+
+  for (const [pkgVersion, info] of Object.entries(report)) {
+    if (SELF_PKG && pkgVersion === SELF_PKG) continue;
+    const lastAt = pkgVersion.lastIndexOf('@');
+    const name = lastAt > 0 ? pkgVersion.slice(0, lastAt) : pkgVersion;
+
+    // Exact-name exemption short-circuits everything: license is irrelevant.
+    const ex = exemptByName.get(name);
+    if (ex) {
+      matchedNames.add(name);
+      exempted.push({ name, pkgVersion, declared: info.licenses, entry: ex });
+      if (ex.review && ex.review < today) expired.push({ kind: 'exemption', name, entry: ex });
+      continue;
+    }
+
+    // License override: replace declared with resolved SPDX, then evaluate.
+    // Used for UNKNOWNs whose LICENSE file is permissive (e.g. map-stream).
+    // Distinct from exemption — these are CORRECTIONS, not policy exceptions.
+    const ov = overrideByName.get(name);
+    const effective = ov ? ov.spdx : info.licenses;
+    if (ov) {
+      matchedNames.add(name);
+      overridden.push({ name, pkgVersion, declared: info.licenses, entry: ov });
+      if (ov.review && ov.review < today) expired.push({ kind: 'override', name, entry: ov });
+    }
+
+    const cls = evalExpr(effective, allowedSet, unauthorizedSet);
+    if (cls === 'allowed') continue;
+
+    // Last resort: narrow prefix exemption (publisher-controlled scope,
+    // uniform license stance — e.g. @img/sharp-libvips-* platform binaries).
+    // NEVER use for general namespaces like @types/ where each sub-package
+    // is independently licensed.
+    const prefixEntry = exemptPrefixes.find((p) => name.startsWith(p.prefix));
+    if (prefixEntry) {
+      matchedPrefixes.add(prefixEntry.prefix);
+      const list = prefixHits.get(prefixEntry.prefix) || [];
+      list.push({ pkgVersion, declared: info.licenses });
+      prefixHits.set(prefixEntry.prefix, list);
+      if (prefixEntry.review && prefixEntry.review < today) {
+        expired.push({ kind: 'exemptionPrefix', name: prefixEntry.prefix, entry: prefixEntry });
+      }
+      continue;
+    }
+
+    // Relative path keeps CI logs portable across runners (no leaked /home/runner/work/…
+    // or local /Users/<name>/ paths) without losing locality info for debugging.
+    const relPath = info.path ? relative(ROOT, info.path) || info.path : '';
+    violations.push({
+      name,
+      pkgVersion,
+      declared: info.licenses,
+      effective,
+      cls,
+      path: relPath,
+      repository: info.repository,
+    });
+  }
+
+  // Drift detection: overrides/exemptions/prefixes whose package(s) are no
+  // longer in the tree. Always informational; gate still exits 0 on a clean
+  // license result.
+  const stale = [];
+  for (const e of allowlist.licenseOverrides || []) {
+    if (!matchedNames.has(e.package)) stale.push({ kind: 'override', name: e.package, entry: e });
+  }
+  for (const e of allowlist.exemptions || []) {
+    if (!matchedNames.has(e.package)) stale.push({ kind: 'exemption', name: e.package, entry: e });
+  }
+  for (const e of allowlist.exemptionPrefixes || []) {
+    if (!matchedPrefixes.has(e.prefix)) stale.push({ kind: 'exemptionPrefix', name: e.prefix, entry: e });
+  }
+
+  if (overridden.length) {
+    console.log(`Overrides applied (${overridden.length}):`);
+    for (const { pkgVersion, declared, entry } of overridden) {
+      console.log(`  ${pkgVersion}  declared=${JSON.stringify(declared)} → spdx=${entry.spdx}`);
+      console.log(`    ${entry.reason}`);
+      console.log(`    added ${entry.added}, review by ${entry.review}`);
+    }
+    console.log('');
+  }
+  if (exempted.length) {
+    console.log(`Exemptions applied (${exempted.length}):`);
+    for (const { pkgVersion, declared, entry } of exempted) {
+      console.log(`  ${pkgVersion}  declared=${JSON.stringify(declared)} → exempt (${entry.spdx})`);
+      console.log(`    ${entry.reason}`);
+      console.log(`    added ${entry.added}, review by ${entry.review}`);
+    }
+    console.log('');
+  }
+  if (prefixHits.size) {
+    console.log(`Prefix exemptions matched (${prefixHits.size}):`);
+    for (const [prefix, hits] of prefixHits) {
+      const entry = exemptPrefixes.find((p) => p.prefix === prefix);
+      console.log(`  prefix ${prefix} → exempt (${entry.spdx}); ${hits.length} package(s)`);
+      for (const h of hits) console.log(`    ${h.pkgVersion}  declared=${JSON.stringify(h.declared)}`);
+      console.log(`    ${entry.reason}`);
+      console.log(`    added ${entry.added}, review by ${entry.review}`);
+    }
+    console.log('');
+  }
+
+  for (const e of expired) {
+    console.log(
+      `::warning::License ${e.kind} for ${e.name} expired on ${e.entry.review}. Re-justify with a fresh review date or remove if the upstream license has been corrected.`,
+    );
+  }
+  for (const s of stale) {
+    console.log(
+      `::warning::License ${s.kind} for ${s.name} is no longer matched by any installed package. Remove it from .supply-chain/license-allowlist.json.`,
+    );
+  }
+
+  if (violations.length) {
+    console.error('');
+    console.error(`::error::${violations.length} license violation(s) in the installed tree:`);
+    for (const v of violations) {
+      console.error(`  [${v.cls}] ${v.pkgVersion}`);
+      console.error(`    license: ${JSON.stringify(v.declared)}`);
+      if (v.effective !== v.declared) console.error(`    effective: ${JSON.stringify(v.effective)}`);
+      if (v.repository) console.error(`    repo: ${v.repository}`);
+      if (v.path) console.error(`    path: ${v.path}`);
+    }
+    console.error(
+      '\nResolve each:\n' +
+        '  (a) license is fine          → add the SPDX id to allowedSpdx[]\n' +
+        '  (b) declared but mis-mapped  → add a licenseOverrides[] entry (CORRECTION; not a policy exception)\n' +
+        '  (c) accepted copyleft        → add to exemptions[] (exact name) with reason + dated review\n' +
+        '  (d) removable                → drop the dependency\n' +
+        'Config: .supply-chain/license-allowlist.json\n',
+    );
+    process.exit(1);
+  }
+
+  const acceptedSummary = `${overridden.length} overridden, ${exempted.length} exempted by name, ${prefixHits.size} prefix group(s)`;
+  console.log(`license-check: OK (${acceptedSummary}, 0 violations) — scope=${scope}.`);
+  process.exit(0);
+});

--- a/scripts/license-check.test.mjs
+++ b/scripts/license-check.test.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for the pure helpers exported by license-check.lib.mjs.
+ * Uses Node's built-in test runner (node:test, available in Node ≥18) — no
+ * new devDependencies. Run with `node --test license-check.test.mjs`.
+ *
+ * Exemption matching, drift detection, and the checker.init integration are
+ * deliberately out of scope here — they require mocking node_modules and are
+ * exercised by the CI license-check job itself on every PR. These tests cover
+ * the failure modes a contributor is most likely to hit when adjusting the
+ * allowlist: alias normalization, the `*` marker, SPDX OR/AND precedence, and
+ * the UNKNOWN/UNLICENSED/Custom early-exits.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalize, evalExpr } from './license-check.lib.mjs';
+
+const allowed = new Set(['MIT', 'Apache-2.0', 'BSD-3-Clause', 'BSD-2-Clause', 'Zlib', 'ISC']);
+const unauthorized = new Set(['GPL-3.0', 'LGPL-3.0', 'AGPL-3.0']);
+
+test('normalize: passes through canonical SPDX', () => {
+  assert.equal(normalize('MIT'), 'MIT');
+  assert.equal(normalize('Apache-2.0'), 'Apache-2.0');
+});
+
+test('normalize: strips the rseidelsohn `*` "guessed from file" marker', () => {
+  assert.equal(normalize('MIT*'), 'MIT');
+  assert.equal(normalize('Apache-2.0**'), 'Apache-2.0');
+});
+
+test('normalize: strips outer parens', () => {
+  assert.equal(normalize('(MIT)'), 'MIT');
+  assert.equal(normalize('((MIT))'), 'MIT');
+});
+
+test('normalize: applies npm-ecosystem aliases', () => {
+  assert.equal(normalize('Apache2'), 'Apache-2.0');
+  assert.equal(normalize('Apache 2.0'), 'Apache-2.0');
+  assert.equal(normalize('Apache License 2.0'), 'Apache-2.0');
+  assert.equal(normalize('Apache Software License'), 'Apache-2.0');
+  assert.equal(normalize('Expat'), 'MIT');
+  assert.equal(normalize('MIT license'), 'MIT');
+  assert.equal(normalize('new BSD'), 'BSD-3-Clause');
+  assert.equal(normalize('Simplified BSD'), 'BSD-2-Clause');
+});
+
+test('normalize: alias lookup is case-insensitive', () => {
+  assert.equal(normalize('APACHE2'), 'Apache-2.0');
+  assert.equal(normalize('expat'), 'MIT');
+});
+
+test('normalize: unknown tokens pass through unchanged', () => {
+  assert.equal(normalize('SomeUnknownLicense'), 'SomeUnknownLicense');
+});
+
+test('evalExpr: plain allowed SPDX → allowed', () => {
+  assert.equal(evalExpr('MIT', allowed, unauthorized), 'allowed');
+});
+
+test('evalExpr: plain unauthorized SPDX → unauthorized', () => {
+  assert.equal(evalExpr('GPL-3.0', allowed, unauthorized), 'unauthorized');
+});
+
+test('evalExpr: plain unknown SPDX → unknown', () => {
+  assert.equal(evalExpr('SomeNewLicense', allowed, unauthorized), 'unknown');
+});
+
+test('evalExpr: UNKNOWN / UNLICENSED / Custom: short-circuit to unknown', () => {
+  assert.equal(evalExpr('UNKNOWN', allowed, unauthorized), 'unknown');
+  assert.equal(evalExpr('unknown', allowed, unauthorized), 'unknown');
+  assert.equal(evalExpr('UNLICENSED', allowed, unauthorized), 'unknown');
+  assert.equal(evalExpr('Custom: see LICENSE', allowed, unauthorized), 'unknown');
+});
+
+test('evalExpr: null / undefined / empty string → unknown', () => {
+  assert.equal(evalExpr(null, allowed, unauthorized), 'unknown');
+  assert.equal(evalExpr(undefined, allowed, unauthorized), 'unknown');
+  assert.equal(evalExpr('', allowed, unauthorized), 'unknown');
+});
+
+test('evalExpr: npm-legacy array form treated as OR', () => {
+  assert.equal(evalExpr(['MIT', 'Apache2'], allowed, unauthorized), 'allowed');
+  assert.equal(evalExpr(['GPL-3.0', 'LGPL-3.0'], allowed, unauthorized), 'unauthorized');
+  assert.equal(evalExpr(['MIT', 'GPL-3.0'], allowed, unauthorized), 'allowed');
+  assert.equal(evalExpr([], allowed, unauthorized), 'unknown');
+});
+
+test('evalExpr: SPDX OR — any allowed disjunct passes', () => {
+  assert.equal(evalExpr('MIT OR GPL-3.0', allowed, unauthorized), 'allowed');
+  assert.equal(evalExpr('GPL-3.0 OR LGPL-3.0', allowed, unauthorized), 'unauthorized');
+});
+
+test('evalExpr: SPDX AND — all must be allowed; any unauthorized fails', () => {
+  assert.equal(evalExpr('MIT AND Zlib', allowed, unauthorized), 'allowed');
+  assert.equal(evalExpr('MIT AND GPL-3.0', allowed, unauthorized), 'unauthorized');
+  assert.equal(evalExpr('MIT AND SomeNewLicense', allowed, unauthorized), 'unknown');
+});
+
+test('evalExpr: outer parens stripped before splitting', () => {
+  assert.equal(evalExpr('(MIT OR GPL-3.0)', allowed, unauthorized), 'allowed');
+  assert.equal(evalExpr('(MIT AND Zlib)', allowed, unauthorized), 'allowed');
+});
+
+test('evalExpr: AND binds tighter than OR — SPDX precedence', () => {
+  // `A AND B OR C` === `(A AND B) OR C`
+  // MIT AND GPL-3.0 → unauthorized; OR with MIT → allowed
+  assert.equal(evalExpr('MIT AND GPL-3.0 OR MIT', allowed, unauthorized), 'allowed');
+  // GPL-3.0 OR MIT AND Zlib → GPL-3.0 OR (MIT AND Zlib) → allowed
+  assert.equal(evalExpr('GPL-3.0 OR MIT AND Zlib', allowed, unauthorized), 'allowed');
+});
+
+test('evalExpr: alias normalization applies inside OR/AND', () => {
+  assert.equal(evalExpr('Apache2 OR GPL-3.0', allowed, unauthorized), 'allowed');
+  assert.equal(evalExpr('Expat AND Zlib', allowed, unauthorized), 'allowed');
+});
+
+test('evalExpr: `*` marker stripped inside compound expressions', () => {
+  assert.equal(evalExpr('MIT*', allowed, unauthorized), 'allowed');
+  assert.equal(evalExpr(['MIT*', 'GPL-3.0'], allowed, unauthorized), 'allowed');
+});

--- a/scripts/license-check.test.mjs
+++ b/scripts/license-check.test.mjs
@@ -12,6 +12,8 @@
  * the UNKNOWN/UNLICENSED/Custom early-exits.
  */
 
+/* eslint-disable no-undef -- standalone test module: uses JS built-in globals (works across legacy + flat eslint configs) */
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -251,6 +251,18 @@
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz#a81ffb00e69267cd0a1d626eaedb8a8430b2b2f8"
   integrity sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -445,6 +457,18 @@
   version "1.0.39"
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
+
+"@npmcli/fs@^3.1.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-3.1.1.tgz#59cdaa5adca95d135fc00f2bb53f5771575ce726"
+  integrity sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==
+  dependencies:
+    semver "^7.3.5"
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@pkgr/core@^0.1.0":
   version "0.1.2"
@@ -764,6 +788,11 @@
     js-yaml "^3.10.0"
     tslib "^2.4.0"
 
+abbrev@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
+  integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -789,12 +818,22 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-regex@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
+
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^6.1.0:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 any-promise@^1.0.0:
   version "1.3.0"
@@ -838,6 +877,11 @@ array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
   dependencies:
     call-bound "^1.0.3"
     is-array-buffer "^3.0.5"
+
+array-find-index@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
+  integrity sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==
 
 array-includes@^3.1.6, array-includes@^3.1.8, array-includes@^3.1.9:
   version "3.1.9"
@@ -977,6 +1021,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
+  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 brace-expansion@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
@@ -1037,7 +1088,7 @@ ccount@^2.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
-chalk@^4.0.0:
+chalk@4.1.2, chalk@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1131,7 +1182,7 @@ cosmiconfig@^9.0.0:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
 
-cross-spawn@^7.0.2:
+cross-spawn@^7.0.2, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -1298,6 +1349,11 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     call-bind-apply-helpers "^1.0.1"
     es-errors "^1.3.0"
     gopd "^1.2.0"
+
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -1811,6 +1867,14 @@ for-each@^0.3.3, for-each@^0.3.5:
   dependencies:
     is-callable "^1.2.7"
 
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1907,6 +1971,18 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
+glob@^10.2.2:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
+
 glob@^7.1.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -1938,6 +2014,11 @@ gopd@^1.0.1, gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
+graceful-fs@^4.1.2:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 graphemer@^1.4.0:
   version "1.4.0"
@@ -1984,6 +2065,13 @@ hasown@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.3.tgz#5e5c2b15b60370a4c7930c383dfb76bf17bc403c"
   integrity sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
@@ -2078,6 +2166,13 @@ hastscript@^9.0.0:
     hast-util-parse-selector "^4.0.0"
     property-information "^7.0.0"
     space-separated-tokens "^2.0.0"
+
+hosted-git-info@^6.0.0:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-6.1.3.tgz#2ee1a14a097a1236bddf8672c35b613c46c55946"
+  integrity sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==
+  dependencies:
+    lru-cache "^7.5.1"
 
 html-url-attributes@^3.0.0:
   version "3.0.1"
@@ -2222,6 +2317,13 @@ is-core-module@^2.16.1:
   integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
   dependencies:
     hasown "^2.0.2"
+
+is-core-module@^2.8.1:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
+  dependencies:
+    hasown "^2.0.3"
 
 is-data-view@^1.0.1, is-data-view@^1.0.2:
   version "1.0.2"
@@ -2406,6 +2508,15 @@ iterator.prototype@^1.1.5:
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
 
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
 jiti@^1.21.6:
   version "1.21.7"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
@@ -2440,6 +2551,11 @@ json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
+json-parse-even-better-errors@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz#b43d35e89c0f3be6b5fbbe9dc6c82467b30c28da"
+  integrity sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -2495,6 +2611,23 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+license-checker-rseidelsohn@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/license-checker-rseidelsohn/-/license-checker-rseidelsohn-4.4.2.tgz#c8136cd5708ef68e5560445bd171cc4a5dc536df"
+  integrity sha512-Sf8WaJhd2vELvCne+frS9AXqnY/vv591s2/nZcJDwTnoNgltG4mAmoenffVb8L2YPRYbxARLyrHJBC38AVfpuA==
+  dependencies:
+    chalk "4.1.2"
+    debug "^4.3.4"
+    lodash.clonedeep "^4.5.0"
+    mkdirp "^1.0.4"
+    nopt "^7.2.0"
+    read-installed-packages "^2.0.1"
+    semver "^7.3.5"
+    spdx-correct "^3.1.1"
+    spdx-expression-parse "^3.0.1"
+    spdx-satisfies "^5.0.1"
+    treeify "^1.1.0"
+
 lilconfig@^3.0.0, lilconfig@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
@@ -2532,6 +2665,11 @@ lockfile-lint@5.0.0:
     lockfile-lint-api "^5.9.2"
     yargs "^17.7.2"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -2548,6 +2686,16 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
+lru-cache@^7.5.1:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
 lucide-react@0.460.0:
   version "0.460.0"
@@ -3044,10 +3192,27 @@ minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^9.0.4:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
+
 minimist@^1.2.0, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
@@ -3119,10 +3284,32 @@ node-exports-info@^1.6.0:
     object.entries "^1.1.9"
     semver "^6.3.1"
 
+nopt@^7.2.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.1.tgz#1cac0eab9b8e97c9093338446eddd40b2c8ca1e7"
+  integrity sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==
+  dependencies:
+    abbrev "^2.0.0"
+
+normalize-package-data@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-5.0.0.tgz#abcb8d7e724c40d88462b84982f7cbf6859b4588"
+  integrity sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==
+  dependencies:
+    hosted-git-info "^6.0.0"
+    is-core-module "^2.8.1"
+    semver "^7.3.5"
+    validate-npm-package-license "^3.0.4"
+
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+npm-normalize-package-bin@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz#25447e32a9a7de1f51362c61a559233b89947832"
+  integrity sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==
 
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
@@ -3237,6 +3424,11 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -3293,6 +3485,14 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path@0.12.7:
   version "0.12.7"
@@ -3495,6 +3695,29 @@ read-cache@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
+read-installed-packages@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/read-installed-packages/-/read-installed-packages-2.0.1.tgz#8ba63a9382a5158c37a288c2f21268d6eb9c85eb"
+  integrity sha512-t+fJOFOYaZIjBpTVxiV8Mkt7yQyy4E6MSrrnt5FmPd4enYvpU/9DYGirDmN1XQwkfeuWIhM/iu0t2rm6iSr0CA==
+  dependencies:
+    "@npmcli/fs" "^3.1.0"
+    debug "^4.3.4"
+    read-package-json "^6.0.0"
+    semver "2 || 3 || 4 || 5 || 6 || 7"
+    slide "~1.1.3"
+  optionalDependencies:
+    graceful-fs "^4.1.2"
+
+read-package-json@^6.0.0:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-6.0.4.tgz#90318824ec456c287437ea79595f4c2854708836"
+  integrity sha512-AEtWXYfopBj2z5N5PbkAOeNHRPUg5q+Nen7QLxV8M2zJq1ym6/lCz3fYNTCXe19puu2d06jfHhrP7v/S2PtMMw==
+  dependencies:
+    glob "^10.2.2"
+    json-parse-even-better-errors "^3.0.0"
+    normalize-package-data "^5.0.0"
+    npm-normalize-package-bin "^3.0.0"
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -3675,6 +3898,11 @@ scriptjs@^2.5.9:
   resolved "https://registry.yarnpkg.com/scriptjs/-/scriptjs-2.5.9.tgz#343915cd2ec2ed9bfdde2b9875cd28f59394b35f"
   integrity sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==
 
+"semver@2 || 3 || 4 || 5 || 6 || 7", semver@^7.3.5:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.2.tgz#194bd65723a28cf82542d2bf176b91c26b343be1"
+  integrity sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==
+
 semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
@@ -3802,6 +4030,16 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
+slide@~1.1.3:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+  integrity sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==
+
 source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -3811,6 +4049,55 @@ space-separated-tokens@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz#1ecd9d2350a3844572c3f4a312bceb018348859f"
   integrity sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
+
+spdx-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-compare/-/spdx-compare-1.0.0.tgz#2c55f117362078d7409e6d7b08ce70a857cd3ed7"
+  integrity sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==
+  dependencies:
+    array-find-index "^1.0.2"
+    spdx-expression-parse "^3.0.0"
+    spdx-ranges "^2.0.0"
+
+spdx-correct@^3.0.0, spdx-correct@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.2.0.tgz#4f5ab0668f0059e34f9c00dce331784a12de4e9c"
+  integrity sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz#5d607d27fc806f66d7b64a766650fa890f04ed66"
+  integrity sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==
+
+spdx-expression-parse@^3.0.0, spdx-expression-parse@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
+  integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.23"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz#b069e687b1291a32f126893ed76a27a745ee2133"
+  integrity sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==
+
+spdx-ranges@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/spdx-ranges/-/spdx-ranges-2.1.1.tgz#87573927ba51e92b3f4550ab60bfc83dd07bac20"
+  integrity sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==
+
+spdx-satisfies@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-satisfies/-/spdx-satisfies-5.0.1.tgz#9feeb2524686c08e5f7933c16248d4fdf07ed6a6"
+  integrity sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==
+  dependencies:
+    spdx-compare "^1.0.0"
+    spdx-expression-parse "^3.0.0"
+    spdx-ranges "^2.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -3830,6 +4117,15 @@ stop-iteration-iterator@^1.1.0:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
 
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -3838,6 +4134,15 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
 
 string.prototype.includes@^2.0.1:
   version "2.0.1"
@@ -3915,12 +4220,26 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -4055,6 +4374,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+treeify@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
+  integrity sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==
 
 trim-lines@^3.0.0:
   version "3.0.1"
@@ -4270,6 +4594,14 @@ util@^0.10.3:
   dependencies:
     inherits "2.0.3"
 
+validate-npm-package-license@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
+
 vfile-location@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-5.0.3.tgz#cb9eacd20f2b6426d19451e0eafa3d0a846225c3"
@@ -4364,6 +4696,15 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -4372,6 +4713,15 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
## What

A PARANOID license-allowlist gate over the **production** dependency tree: every production dependency's license must be on the allowlist in `.supply-chain/license-allowlist.json`, corrected by an override, or an explicitly-reasoned exemption. `UNKNOWN`/unlisted licenses fail.

Engine: `license-checker-rseidelsohn` (reads actual `LICENSE` files, so packages declaring no SPDX string are classified rather than reported `UNKNOWN`). The SPDX policy logic is hand-rolled and unit-tested — no extra parser dependency.

## Files
- **`scripts/license-check.mjs`** (+ `license-check.lib.mjs` evaluator + `license-check.test.mjs` unit tests) — the gate. SPDX `OR`/`AND` handling, PARANOID on unresolved licenses, exemptions by exact package name (version-agnostic) + a narrow publisher-controlled prefix for platform-binary families.
- **`.supply-chain/license-allowlist.json`** — allowlist + reasoned exemptions (same `reason`+`review` discipline as `audit-allowlist.json`).
- **`.github/workflows/main.yml`** — one CI job, intentionally **not** in the `all-checks-passed` aggregator (reports without gating merges).
- **`package.json`** — one devDependency (`license-checker-rseidelsohn@4.4.2` — pinned to the 4.x line, which supports Node ≥18; the 5.x line requires Node 24) + `license-check` / `license-check:test` scripts.

## Non-breaking by design
- `dependencies` and `resolutions` are **untouched** — only a devDep + scripts.
- **Non-blocking pilot:** not in the aggregator's `needs:`, so it cannot fail any current merge.
- `yarn.lock` change is additive (only the checker + its transitives).

## Result
- `yarn license-check` → **PASS, 0 violations** (1 prefix-exempted: `@img/sharp-libvips-*`, LGPL-3.0 dynamically-loaded libvips native binary via `next > sharp`).
- `yarn license-check:test` → **18/18**.

## Promote to required later
Add `license-check` to `all-checks-passed.needs` (+ branch protection) once the `@img/sharp-libvips-` exemption is signed off.